### PR TITLE
Fix version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dmitryrechkin/json-schema-to-zod": "^1.0.1",
         "@langchain/anthropic": "^0.3.14",
-        "@langchain/core": "0.3.58",
+        "@langchain/core": "0.3.71",
         "@langchain/openai": "^0.5.15",
         "@modelcontextprotocol/sdk": "1.12.1",
         "@scarf/scarf": "^1.4.0",
@@ -1238,9 +1238,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.58",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.58.tgz",
-      "integrity": "sha512-HLkOtVofgBHefaUae/+2fLNkpMLzEjHSavTmUF0YC7bDa5NPIZGlP80CGrSFXAeJ+WCPd8rIK8K/p6AW94inUQ==",
+      "version": "0.3.71",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.71.tgz",
+      "integrity": "sha512-ejArFmm/lZ9je2rbMLpkFZnva8jkvDhFCn370WAAVP8akbPOLgDA+S2e5jvj+G/oHraOwmviY8EnxbPXXcDvfw==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -1248,7 +1248,7 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.29",
+        "langsmith": "^0.3.46",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@dmitryrechkin/json-schema-to-zod": "^1.0.1",
     "@langchain/anthropic": "^0.3.14",
-    "@langchain/core": "0.3.58",
+    "@langchain/core": "0.3.71",
     "@langchain/openai": "^0.5.15",
     "@modelcontextprotocol/sdk": "1.12.1",
     "@scarf/scarf": "^1.4.0",


### PR DESCRIPTION
# Description
Fix the issue when running examples.

## Problem
The mcp-use package has `@langchain/core@0.3.58` as a dependency
The any other project is pulling in `@langchain/core@0.3.71` through its other dependencies (`@langchain/openai`, `langfuse-langchain`)
This creates type incompatibilities between the same interfaces from different versions.

Resolves #18 